### PR TITLE
Send through carefully assembled hadoop config to parquet writer

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
+++ b/src/main/java/io/confluent/connect/hdfs/parquet/ParquetRecordWriterProvider.java
@@ -49,7 +49,7 @@ public class ParquetRecordWriterProvider implements RecordWriterProvider {
 
     Path path = new Path(fileName);
     final ParquetWriter<GenericRecord> writer =
-        new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize);
+        new AvroParquetWriter<>(path, avroSchema, compressionCodecName, blockSize, pageSize, true, conf);
 
     return new RecordWriter<SinkRecord>() {
       @Override


### PR DESCRIPTION
If you don't pass config through then writer build empty config
which does not allow to resolve HA HDFS addresses
