### PR TITLE
Pass path.format configuration to CreationTimePartitioner

### DIFF
--- a/src/main/java/io/confluent/connect/hdfs/partitioner/CreationTimePartitioner.java
+++ b/src/main/java/io/confluent/connect/hdfs/partitioner/CreationTimePartitioner.java
@@ -28,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public class CreationTimePartitioner implements Partitioner {
     private static final Logger log = LoggerFactory.getLogger(FieldPartitioner.class);
     private static long partitionDurationMs = TimeUnit.HOURS.toMillis(1);
-    private static String pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH/";
+    private String pathFormat = "'year'=YYYY/'month'=MM/'day'=dd/'hour'=HH/";
     private String fieldName = "creation_timestamp";
 
     // Duration of a partition in milliseconds.
@@ -71,6 +71,12 @@ public class CreationTimePartitioner implements Partitioner {
         }
 
         String hiveIntString = (String) config.get(HdfsSinkConnectorConfig.HIVE_INTEGRATION_CONFIG);
+
+        String pathFormatFromConfiguration = (String) config.get(HdfsSinkConnectorConfig.PATH_FORMAT_CONFIG);
+        if (pathFormatFromConfiguration != null && !pathFormatFromConfiguration.equals("")) {
+            pathFormat = pathFormatFromConfiguration;
+        }
+
         boolean hiveIntegration = hiveIntString != null && hiveIntString.toLowerCase().equals("true");
         Locale locale = new Locale(localeString);
         DateTimeZone timeZone = DateTimeZone.forID(timeZoneString);

--- a/src/test/java/io/confluent/connect/hdfs/partitioner/CreationTimePartitionerTest.java
+++ b/src/test/java/io/confluent/connect/hdfs/partitioner/CreationTimePartitionerTest.java
@@ -108,6 +108,23 @@ public class CreationTimePartitionerTest {
         }
     }
 
+    @Test
+    public void testCustomPartitionedPath() throws Exception {
+        Map<String, Object> config = createConfig();
+
+        CreationTimePartitioner partitioner = new CreationTimePartitioner();
+        config.put("path.format", "'year'=YYYY/'month'=M/'day'=d/'hour'=H/");
+        partitioner.configure(config);
+
+        String pathFormat = partitioner.getPathFormat();
+        String timeZoneString = (String) config.get(HdfsSinkConnectorConfig.TIMEZONE_CONFIG);
+        long timestamp = new DateTime(2016, 4, 6, 14, 0, 0, 0, DateTimeZone.forID(timeZoneString)).getMillis();
+        String encodedPartition = TimeUtils.encodeTimestamp(partitionDurationMs, pathFormat,
+                timeZoneString, timestamp);
+        String path = partitioner.generatePartitionedPath("topic", encodedPartition);
+        assertEquals("topic/year=2016/month=4/day=6/hour=14/", path);
+    }
+
     private Map<String, Object> createConfig() {
         Map<String, Object> config = new HashMap<>();
         config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, "en");
@@ -118,7 +135,6 @@ public class CreationTimePartitionerTest {
     private Map<String, Object> createConfigWithCustomFieldName(String fieldName) {
         Map<String, Object> config = new HashMap<>();
         config.put(HdfsSinkConnectorConfig.LOCALE_CONFIG, "en");
-        config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, "UTC");
         config.put(HdfsSinkConnectorConfig.TIMEZONE_CONFIG, "UTC");
         config.put(HdfsSinkConnectorConfig.PARTITION_FIELD_NAME_CONFIG, fieldName);
         return config;


### PR DESCRIPTION
Now we can use `path.format` to override in configuration partitioning.
